### PR TITLE
revise RPM version approach

### DIFF
--- a/python-psphere.spec.in
+++ b/python-psphere.spec.in
@@ -1,11 +1,11 @@
 Summary: vSphere SDK for Python
 Name: python-psphere
 Version: @VERSION@
-Release: 1%{?dist}
+Release: @RELEASE@%{?dist}
 Source0: %{name}-%{version}.tar.gz
 License: ASL 2.0
 Group: Development/Libraries
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+BuildRoot: %{_tmppath}/%{name}-%{version}-buildroot
 Prefix: %{_prefix}
 BuildArch: noarch
 Url: http://jkinred.bitbucket.org/psphere

--- a/python-psphere.spec.in
+++ b/python-psphere.spec.in
@@ -31,6 +31,9 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root)
 
 %changelog
+* Wed Aug 28 2013 Ian McLeod <imcleod@redhat.com> - 0.5.2-1
+- rebase with upstream 0.5.2
+
 * Thu Mar 15 2012 Ian McLeod <imcleod@redhat.com> - 0.1-5
 - Remove Vendor field from SPEC file
 


### PR DESCRIPTION
This approach abandons using the output of "git describe" to produce a version string in favor of either and explicit VERSION and RELEASE variable in setup.py or, if RELEASE is "0", a timestamp.  This mirrors a change we made in image factory, which is where the earlier RPM approach came from.

This avoids some odd issues with RPM version math that arose with the earlier approach, particularly when squashing commits before merging them into master.
