### PR TITLE
Enable rpm build for user's home directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,16 @@ version:
 	git describe --tags > version.txt
 	perl -p -i -e 's/-/./g' version.txt
 
-sdist:
+sdist: version
 	python setup.py sdist
 
-signed-rpm: sdist version
+signed-rpm: sdist
 	rpmbuild -ba python-psphere.spec --sign --define "_sourcedir `pwd`/dist"
 
-rpm: sdist version
+rpm: sdist
 	rpmbuild -ba python-psphere.spec --define "_sourcedir `pwd`/dist"
 
-srpm: sdist version
+srpm: sdist
 	rpmbuild -bs python-psphere.spec --define "_sourcedir `pwd`/dist"
 
 pylint:

--- a/setup.py
+++ b/setup.py
@@ -23,13 +23,21 @@ def subprocess_check_output(*popenargs, **kwargs):
         raise Exception("'%s' failed(%d): %s" % (cmd, retcode, stderr))
     return (stdout, stderr, retcode)
 
-try:
-    command = '/usr/bin/git describe --tags  | tr - .'
-    print command
-    (pkg_version, ignore, ignore) = subprocess_check_output(command, shell=True)
-    pkg_version = pkg_version.rstrip('\n')
-except:
-    pkg_version = 9999
+if os.path.isfile("PKG-INFO"):
+    f=open("PKG-INFO")
+    for line in f:
+        if line.startswith("Version:"):
+            pkg_version=line.split(":")[1].rsplit()[0]
+            break
+    f.close()
+else:
+    try:
+        """ open file """
+        f=open("version.txt")
+        pkg_version=f.readline().rstrip()
+        f.close()
+    except:
+        pkg_version="999999"
 
 def modify_specfile():
     cmd = (' sed -e "s/@VERSION@/%s/g" < python-psphere.spec.in ' % pkg_version) + " > python-psphere.spec"


### PR DESCRIPTION
Hi Jonathan,

this is to enable rpmbuild in user's home directory. For this to work I needed to change the _ in the version number to be replaced by . and the read the version number out of the spec file once created.

Cheers,

Frank
